### PR TITLE
Verify if(state[v.field] == undefined)

### DIFF
--- a/src/FormValidator.js
+++ b/src/FormValidator.js
@@ -14,7 +14,12 @@ class FormValidator {
               typeof v.method === 'string' ?
               validator[v.method] : 
               v.method
-              
+        
+        if(state[v.field] == undefined) {
+          validation[v.field] = { isInvalid: true, message: v.message }
+          validation.isValid = false;
+        }
+        else      
         if(validation_method(state[v.field].toString(), ...args, state) !== v.validWhen) {
           validation[v.field] = { isInvalid: true, message: v.message }
           validation.isValid = false;


### PR DESCRIPTION
improvement in Validation Form when we forgot initialise state, maybe in this case a default error message was returned